### PR TITLE
Upgrade to Kafka 1.0, Scala 2.12, and upgrade other dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,15 @@
     </parent>
 
     <groupId>com.cj</groupId>
-    <artifactId>kafka-rx_2.11</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <artifactId>kafka-rx_2.12</artifactId>
+    <version>0.4.0-SNAPSHOT</version>
 
     <properties>
-        <kafka.version>0.8.2.1</kafka.version>
-        <curator.version>2.8.0</curator.version>
-        <rx.scala.version>0.25.0</rx.scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scala.compiler.version>2.11.6</scala.compiler.version>
+        <kafka.version>1.0.0</kafka.version>
+        <curator.version>2.12.0</curator.version>
+        <rx.scala.version>0.26.5</rx.scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
+        <scala.compiler.version>2.12.4</scala.compiler.version>
     </properties>
 
     <dependencies>
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.compat.version}</artifactId>
-            <version>2.1.3</version>
+            <version>3.0.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -60,6 +60,7 @@
             <version>${curator.version}</version>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/scala/com/cj/kafka/rx/RxConsumer.scala
+++ b/src/main/scala/com/cj/kafka/rx/RxConsumer.scala
@@ -17,11 +17,11 @@ class RxConsumer(config: ConsumerConfig, committer: OffsetCommitter) {
   private var kafkaConsumer: ConsumerConnector = null
   private var offsetCommitter: OffsetCommitter = committer
 
-  def getRecordStream[K, V](topic: String, keyDecoder: Decoder[K] = new DefaultDecoder, valueDecoder: Decoder[V] = new DefaultDecoder) = {
+  def getRecordStream[K, V](topic: String, keyDecoder: Decoder[K] = new DefaultDecoder[K], valueDecoder: Decoder[V] = new DefaultDecoder) = {
     getRecordStreams(topic, 1, keyDecoder, valueDecoder)(0)
   }
 
-  def getRecordStreams[K, V](topic: String, numStreams: Int = 1, keyDecoder: Decoder[K] = new DefaultDecoder, valueDecoder: Decoder[V] = new DefaultDecoder) = {
+  def getRecordStreams[K, V](topic: String, numStreams: Int = 1, keyDecoder: Decoder[K] = new DefaultDecoder[K], valueDecoder: Decoder[V] = new DefaultDecoder[K]) = {
     val kafkaStreams: Seq[KafkaStream[K, V]] = ensureKafkaConsumer().createMessageStreamsByFilter[K, V](
       new Whitelist(topic),
       numStreams = numStreams,

--- a/src/main/scala/com/cj/kafka/rx/RxConsumer.scala
+++ b/src/main/scala/com/cj/kafka/rx/RxConsumer.scala
@@ -17,11 +17,11 @@ class RxConsumer(config: ConsumerConfig, committer: OffsetCommitter) {
   private var kafkaConsumer: ConsumerConnector = null
   private var offsetCommitter: OffsetCommitter = committer
 
-  def getRecordStream[K, V](topic: String, keyDecoder: Decoder[K] = new DefaultDecoder[K], valueDecoder: Decoder[V] = new DefaultDecoder) = {
+  def getRecordStream[K, V](topic: String, keyDecoder: Decoder[K] = new DefaultDecoder, valueDecoder: Decoder[V] = new DefaultDecoder) = {
     getRecordStreams(topic, 1, keyDecoder, valueDecoder)(0)
   }
 
-  def getRecordStreams[K, V](topic: String, numStreams: Int = 1, keyDecoder: Decoder[K] = new DefaultDecoder[K], valueDecoder: Decoder[V] = new DefaultDecoder[K]) = {
+  def getRecordStreams[K, V](topic: String, numStreams: Int = 1, keyDecoder: Decoder[K] = new DefaultDecoder, valueDecoder: Decoder[V] = new DefaultDecoder) = {
     val kafkaStreams: Seq[KafkaStream[K, V]] = ensureKafkaConsumer().createMessageStreamsByFilter[K, V](
       new Whitelist(topic),
       numStreams = numStreams,

--- a/src/test/scala/com/cj/kafka/rx/CommittableTest.scala
+++ b/src/test/scala/com/cj/kafka/rx/CommittableTest.scala
@@ -2,7 +2,7 @@ package com.cj.kafka.rx
 
 import org.scalatest._
 
-class CommittableTest extends FlatSpec with ShouldMatchers {
+class CommittableTest extends FlatSpec with Matchers {
 
   "Committable" should "pass along a commit context to derivatives" in {
     var passing = false

--- a/src/test/scala/com/cj/kafka/rx/OffsetManagerTest.scala
+++ b/src/test/scala/com/cj/kafka/rx/OffsetManagerTest.scala
@@ -1,9 +1,9 @@
 package com.cj.kafka.rx
 
 import kafka.message.MessageAndMetadata
-import org.scalatest.{FlatSpec, ShouldMatchers}
+import org.scalatest.{FlatSpec, Matchers}
 
-class OffsetManagerTest extends FlatSpec with ShouldMatchers {
+class OffsetManagerTest extends FlatSpec with Matchers {
 
   type RxMessage = Record[Array[Byte], Array[Byte]]
   type KafkaMessage = MessageAndMetadata[Array[Byte], Array[Byte]]

--- a/src/test/scala/com/cj/kafka/rx/ProducerRecordTest.scala
+++ b/src/test/scala/com/cj/kafka/rx/ProducerRecordTest.scala
@@ -1,7 +1,8 @@
 package com.cj.kafka.rx
 
-import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata, MockProducer}
-import org.scalatest.{Matchers, BeforeAndAfter, FlatSpec}
+import org.apache.kafka.clients.producer.{MockProducer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import rx.lang.scala.Observable
 
 import scala.collection.JavaConversions._
@@ -23,7 +24,7 @@ class ProducerRecordTest extends FlatSpec with Matchers with BeforeAndAfter {
 
         val messages = urls.map(s => new Record(key = s.getBytes("UTF-8"), value = s.getBytes("UTF-8"), "", 0, 0))
         val stream = Observable.from(messages)
-        val producer = new MockProducer()
+        val producer = new MockProducer(true, new ByteArraySerializer(), new ByteArraySerializer())
 
         def pred(s: String) = s.toLowerCase.contains("/include-me")
 
@@ -55,7 +56,7 @@ class ProducerRecordTest extends FlatSpec with Matchers with BeforeAndAfter {
         ) map { x =>
             x.produce("lol")
         }
-        val fakeProducer = new MockProducer()
+        val fakeProducer = new MockProducer(true, new ByteArraySerializer(), new ByteArraySerializer())
         val result = stream.saveToKafka(fakeProducer).toBlocking.toList
 
         result.last.commit()

--- a/src/test/scala/com/cj/kafka/rx/RxConsumerIntegrationTest.scala
+++ b/src/test/scala/com/cj/kafka/rx/RxConsumerIntegrationTest.scala
@@ -6,14 +6,15 @@ import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.RetryUntilElapsed
 import org.apache.curator.test.TestingServer
 import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.scalatest._
 import rx.lang.scala.subjects.{PublishSubject, ReplaySubject}
-import rx.lang.scala.{Observer, Observable}
+import rx.lang.scala.{Observable, Observer}
 import rx.lang.scala.observables.ConnectableObservable
 
 import collection.JavaConversions._
 
-class RxConsumerIntegrationTest extends FlatSpec with ShouldMatchers with BeforeAndAfter {
+class RxConsumerIntegrationTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   "KafkaObservable" should "provide an observable stream" in {
     val conn = new RxConsumer("test", "test")
@@ -85,7 +86,7 @@ class RxConsumerIntegrationTest extends FlatSpec with ShouldMatchers with Before
 
   it should "deliver messages to a producer" in {
     val fakeStream = Observable.from(getFakeKafkaMessages(10) map { msg => new Record(msg) })
-    val producer = new MockProducer(true)
+    val producer = new MockProducer(true, new ByteArraySerializer(), new ByteArraySerializer())
     val savedMessages = fakeStream.map(_.produce("test-topic")).saveToKafka(producer).toBlocking.toList
     val history = producer.history
     savedMessages.size should be(10)

--- a/src/test/scala/com/cj/kafka/rx/ZookeeperOffsetCommitterIntegrationTest.scala
+++ b/src/test/scala/com/cj/kafka/rx/ZookeeperOffsetCommitterIntegrationTest.scala
@@ -8,9 +8,9 @@ import org.apache.curator.utils.EnsurePath
 
 import scala.concurrent.duration._
 
-import org.scalatest.{BeforeAndAfter, FlatSpec, ShouldMatchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class ZookeeperOffsetCommitterIntegrationTest extends FlatSpec with ShouldMatchers with BeforeAndAfter {
+class ZookeeperOffsetCommitterIntegrationTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   var server: TestingServer = _
   var client: CuratorFramework = _


### PR DESCRIPTION
Test pass. Tried to upgrade Curator to latest with no success.